### PR TITLE
dependency on more stable version of dc-js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "!dist/**/*"
   ],
   "dependencies": {
-    "dcjs": "https://github.com/dc-js/dc.js.git#develop",
+    "dcjs": "https://github.com/dc-js/dc.js.git#~2.0.0",
     "leaflet": "~0.7.3",
     "leaflet.markercluster": "~0.4.0",
     "d3-tip": "~0.6.6",

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "!dist/**/*"
   ],
   "dependencies": {
-    "dcjs": "https://github.com/dc-js/dc.js.git#~2.0.0",
+    "dcjs": "dc-js/dc.js#~2.0.0",
     "leaflet": "~0.7.3",
     "leaflet.markercluster": "~0.4.0",
     "d3-tip": "~0.6.6",


### PR DESCRIPTION
Just a thought. Wouldn't it be better to use a more stable version of dc-js dependency than referencing develop branch.
