### PR TITLE
Account for _markerList being an object

### DIFF
--- a/src/scripts/leaflet-marker-chart.js
+++ b/src/scripts/leaflet-marker-chart.js
@@ -285,7 +285,7 @@
                     dc.redrawAll(_chart.chartGroup());
                 });
             } else if (_chart.filter() && (e.type === 'click' ||
-                                           (_markerList.indexOf(_chart.filter()) !== -1 &&
+                                           (_markerList.hasOwnProperty(_chart.filter()) &&
                                             !_chart.map().getBounds().contains(_markerList[_chart.filter()].getLatLng())))) {
                 dc.events.trigger(function () {
                     _chart.filter(null);


### PR DESCRIPTION
Looks like `dc.leafletMarkerChart`'s internal `_markerList` was changed from an array to an object in 160449a021fb83cd27cd98e1d1763df399b275d8; this use of `indexOf` didn't get changed, and it seems to be causing #17 .
