### PR TITLE
Set marker opacity based on chart filter

### DIFF
--- a/src/scripts/leaflet-marker-chart.js
+++ b/src/scripts/leaflet-marker-chart.js
@@ -18,7 +18,6 @@
         var _zooming = false;
         var _layerGroup = false;
         var _markerList = {};
-        var _currentGroups = false;
 
         var _fitOnRender = true;
         var _fitOnRedraw = false;
@@ -78,10 +77,6 @@
             var groups = _chart._computeOrderedGroups(_chart.data()).filter(function (d) {
                 return _chart.valueAccessor()(d) !== 0;
             });
-            if (_currentGroups && _currentGroups.toString() === groups.toString()) {
-                return;
-            }
-            _currentGroups = groups;
 
             if (_rebuildMarkers) {
                 _markerList = {};
@@ -98,6 +93,16 @@
                 else {
                     marker = createmarker(v,key);
                 }
+
+                var curFilters = _chart.filters();
+                var markerOpacity = curFilters.length ? 0.3 : 1.0;
+                curFilters.forEach(function (filter) {
+                    if (key === filter) {
+                        markerOpacity = 1.0;
+                    }
+                });
+                marker.setOpacity(markerOpacity);
+
                 if (!_chart.cluster()) {
                     _layerGroup.addLayer(marker);
                 }


### PR DESCRIPTION
Change marker opacity based on chart filters to make the leaflet marker chart visually consistent with other dc.js charts; fixes #19.
