### PR TITLE
fix lookup for bubble and row title lookups

### DIFF
--- a/src/scripts/tooltip-mixin.js
+++ b/src/scripts/tooltip-mixin.js
@@ -21,7 +21,7 @@
                     }
 
                     // get all elements that want a tooltip
-                    _chart.tip.elements = wrapper.selectAll('rect.bar,circle.dot,g.pie-slice,circle.bubble,g.row rect');
+                    _chart.tip.elements = wrapper.selectAll('rect.bar,circle.dot,g.pie-slice,circle.bubble,g.row,g.node');
 
                     // nothing to tip so exit
                     if (_chart.tip.elements.empty()) {


### PR DESCRIPTION
Titles weren't being removed from row and bubble charts, so on mouseover you'd see the tooltip mixin AND the default browser title hover. This resolves that. 