### PR TITLE
use _clusterOptions when creating MarkerClusterer

### DIFF
--- a/dist/google-map/dc-google.js
+++ b/dist/google-map/dc-google.js
@@ -399,7 +399,7 @@
             }
 
             if (_cluster) {
-                _layerGroup = new MarkerClusterer(_chart.map());
+                _layerGroup = new MarkerClusterer(_chart.map(), [], _clusterOptions);
             }
         };
 


### PR DESCRIPTION
MarkerClusterer constructor accepts a third parameter (options). googleMarkerChart class declares _clusterOptions member but never uses it.

I have modified the MarkerClusterer constructor to pass the _clusterOptions parameter.